### PR TITLE
Document auto-commit vs asynchronous pre-flush (KEEP_OPEN_ASYNC)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -432,6 +432,17 @@ Uncommitted changes are held in an in-memory **transaction intent log (TIL)**. O
 
 Because each resource is an independent log-structured store, write transactions on different resources proceed in parallel with no coordination.
 
+### Auto-commit and the asynchronous pre-flush
+
+Long-running write transactions can bound memory and commit latency in two ways, and the distinction matters:
+
+- **Synchronous auto-commit** (after every N modifications and/or every T seconds) runs the *full* commit protocol: it creates a real revision with its own commit record, exactly like an explicit `commit()`, and the transaction stays open.
+- **Asynchronous pre-flush** (`AfterCommitState.KEEP_OPEN_ASYNC`) is *not a commit*. The transaction intent log takes an O(1) snapshot (freezing its current entries), and a background thread writes the snapshot's leaf pages to the data file through shadow references while the writer keeps working on a fresh log generation. No revision, no commit record, nothing becomes visible — if the process crashes before the next real commit, the pre-flushed bytes are unreachable dead space in the append-only file, exactly like a rolled-back transaction.
+
+At the next real commit, leaf pages that were **not** modified after the snapshot are reused by their already-written disk offsets (and content hashes) — the bulk of the commit's I/O has already happened off the commit path. Pages that **were** modified after the snapshot are copied on write into the current log generation; the new copy is authoritative, the earlier flush is superseded, and a forwarding link guarantees every reference resolves to the new version rather than the stale one. Superseded flushes stay behind as unreachable dead bytes — a deliberate write-amplification trade-off on write-hot pages in exchange for low-latency commits.
+
+Two invariants hold unconditionally: **every revision has a commit record** (there is no code path that creates a revision without one — the async pre-flush creates no revision at all), and **only reachable pages carry authority** — page hashes embedded in parent pages cover exactly what a revision can read, never dead space.
+
 ## Secondary Indexes
 
 SirixDB supports three types of user-defined secondary indexes, all stored in the same versioned trie structure as the data. Indexes are part of the transaction and version with the data — the index at revision 42 always matches the data at revision 42.

--- a/docs/transactional-cursor-api.md
+++ b/docs/transactional-cursor-api.md
@@ -744,6 +744,47 @@ session.beginNodeTrx(1000);
 session.beginNodeTrx(1000, TimeUnit.SECONDS, 30);
 ```
 
+Each synchronous auto-commit is a **real commit**: it creates a revision with
+its own commit record — exactly like calling `commit()` yourself — and the
+transaction stays open for further modifications. A bulk load with
+`beginNodeTrx(262_144)` therefore produces one revision per 262,144
+modifications.
+
+#### Asynchronous pre-flush (`KEEP_OPEN_ASYNC`)
+
+For ingest-heavy workloads there is a third mode that is often confused with
+auto-commit but deliberately is **not a commit**:
+
+```java
+// Pre-flush leaf pages in the background after every 262,144th modification;
+// an actual revision is only created when you call commit().
+session.beginNodeTrx(262_144, AfterCommitState.KEEP_OPEN_ASYNC);
+```
+
+When the threshold is reached, the transaction's in-memory intent log takes an
+O(1) snapshot and a **background thread** writes the snapshot's leaf pages to
+the data file, while your thread keeps inserting without waiting for I/O. No
+revision is created, no commit record is written, and none of the pre-flushed
+data becomes visible to readers — if the process crashes before your next real
+`commit()`, the pre-flushed bytes are unreachable and simply ignored, exactly
+like a rolled-back transaction.
+
+The benefit arrives at the next real `commit()`: leaf pages that were not
+modified again since the pre-flush are reused by their already-written disk
+locations, so the bulk of the commit's I/O has already happened in the
+background. Pages you modified *after* the pre-flush are written fresh (the
+engine copies them on write and transparently supersedes the stale flushed
+version — the earlier flush becomes unreachable dead space in the append-only
+file, a deliberate write-amplification trade-off on write-hot pages).
+
+Notes:
+
+- `KEEP_OPEN_ASYNC` currently requires the default `FILE_CHANNEL` storage
+  backend.
+- Durability semantics are unchanged: only `commit()` (or a synchronous
+  auto-commit) makes data durable *and visible*. The pre-flush is purely a
+  latency optimization for the eventual commit.
+
 Furthermore, you're able to start a read-write transaction and then revert to a former revision:
 
 ```java


### PR DESCRIPTION
Documents the distinction between synchronous auto-commits and the `KEEP_OPEN_ASYNC` background pre-flush on two pages:

- **docs/architecture.md** (Transaction Model): sync auto-commits run the full commit protocol (one revision + commit record each); the async pre-flush is *not* a commit — TIL snapshot, background shadow-writes of leaf pages, no revision, nothing visible; superseded flushes become unreachable dead space, unmodified pages' offsets and hashes are reused at the next real commit; plus the two invariants (revision ⇔ commit record; only reachable bytes carry authority).
- **docs/transactional-cursor-api.md**: user-facing semantics with an `AfterCommitState.KEEP_OPEN_ASYNC` example, the FILE_CHANNEL-only constraint, and the note that durability/visibility semantics are unchanged — only real commits publish data.

Mirrors the new section in the main repo's `docs/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM)_